### PR TITLE
Clients and providers

### DIFF
--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -1,0 +1,2 @@
+# Cloud storage provider to use
+#provider:

--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -25,6 +25,7 @@
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
 require_relative 'commands'
+require_relative 'errors'
 require_relative 'version'
 
 require 'tty/reader'

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -35,10 +35,28 @@ module Storage
       end
     end
 
+    def self.creds_schema
+      Hash.new
+    end
+
     attr_reader :credentials
 
     def initialize(credentials: {})
+      raise "Invalid credentials" unless validate_credentials(credentials)
       @credentials = credentials
     end
+
+    private
+
+    def validate_credentials(hash)
+      hash.has_shape?(self.class.creds_schema)
+    end
+  end
+end
+
+class Hash
+  def has_shape?(shape)
+    # Currently only supports single level hashes
+    (shape.keys - self.keys).empty? && all? { |k, v| shape[k] === v }
   end
 end

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -24,7 +24,20 @@
 # For more information on Flight Storage, please visit:
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
+
 module Storage
-  StorageError = Class.new(RuntimeError)
-  AbstractMethodError = Class.new(StandardError)
+  class Client
+    ACTIONS = %w(list push pull delete)
+    PROVIDERS = %w( aws )
+
+    ACTIONS.each do |action|
+      define_method(action) do |*args, **kwargs|
+        raise AbstractMethodError.new "Action not defined for provider"
+      end
+    end
+
+    def initialize(provider:)
+
+    end
+  end
 end

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -25,8 +25,6 @@
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
 
-require_relative 'providers/aws_client'
-
 module Storage
   class Client
     ACTIONS = %w(list push pull delete)
@@ -38,8 +36,11 @@ module Storage
       end
     end
 
+    attr_reader :provider
+
     def initialize(provider:)
-      raise "Invalid provider" if !valid_provider(provider)
+      raise "Invalid provider" if !self.class.valid_provider?(provider)
+      @provider = provider
     end
 
     private

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -25,6 +25,8 @@
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
 
+require_relative 'providers/aws_client'
+
 module Storage
   class Client
     ACTIONS = %w(list push pull delete)
@@ -37,7 +39,13 @@ module Storage
     end
 
     def initialize(provider:)
+      raise "Invalid provider" if !valid_provider(provider)
+    end
 
+    private
+
+    def self.valid_provider?(provider)
+      PROVIDERS.include?(provider)
     end
   end
 end

--- a/lib/storage/client_factory.rb
+++ b/lib/storage/client_factory.rb
@@ -19,26 +19,27 @@
 # You should have received a copy of the Eclipse Public License 2.0
 # along with Flight Storage. If not, see:
 #
-#  https://opensource.org/licenses/EPL-2.0
-#
 # For more information on Flight Storage, please visit:
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
 
-module Storage
-  class Client
-    ACTIONS = %w(list push pull delete)
+require_relative 'providers/example'
 
-    ACTIONS.each do |action|
-      define_method(action) do |*args, **kwargs|
-        raise AbstractMethodError.new "Action not defined for provider"
-      end
+module Storage
+  class ClientFactory
+    PROVIDERS = { 
+      example: ExampleClient
+    }
+
+    def self.for(provider, credentials: {})
+      raise "Invalid provider type" unless valid_provider?(provider)
+      (PROVIDERS[provider]).new(credentials: credentials)
     end
 
-    attr_reader :credentials
+    private
 
-    def initialize(credentials: {})
-      @credentials = credentials
+    def self.valid_provider?(provider)
+      PROVIDERS.include?(provider)
     end
   end
 end

--- a/lib/storage/command.rb
+++ b/lib/storage/command.rb
@@ -26,6 +26,9 @@
 #==============================================================================
 require 'ostruct'
 
+require_relative 'client'
+require_relative 'config'
+
 module Storage
   class Command
     attr_accessor :args, :options
@@ -42,6 +45,16 @@ module Storage
 
     def run
       raise NotImplementedError
+    end
+
+    private
+
+    def provider
+      @provider ||= Config.data.fetch(:provider).downcase
+    end
+
+    def client
+      @client ||= Client.new(provider: provider)
     end
   end
 end

--- a/lib/storage/command.rb
+++ b/lib/storage/command.rb
@@ -26,7 +26,7 @@
 #==============================================================================
 require 'ostruct'
 
-require_relative 'client'
+require_relative 'client_factory'
 require_relative 'config'
 
 module Storage
@@ -49,12 +49,10 @@ module Storage
 
     private
 
-    def provider
-      @provider ||= Config.data.fetch(:provider).downcase
-    end
-
     def client
-      @client ||= Client.new(provider: provider)
+      provider = Config.provider
+      creds = Config.provider_credentials
+      @client ||= ClientFactory.for(provider, credentials: creds)
     end
   end
 end

--- a/lib/storage/config.rb
+++ b/lib/storage/config.rb
@@ -85,6 +85,15 @@ module Storage
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
       end
 
+      def provider
+        data.fetch(:provider).downcase.to_sym
+      end
+
+      def provider_credentials
+        # TODO: come up with a safe way to fetch credentials
+        Hash.new
+      end
+
       private
       def xdg_config
         @xdg_config ||= XDG::Config.new

--- a/lib/storage/providers/example.rb
+++ b/lib/storage/providers/example.rb
@@ -25,20 +25,10 @@
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
 
+require_relative '../client'
+
 module Storage
-  class Client
-    ACTIONS = %w(list push pull delete)
+  class ExampleClient < Client
 
-    ACTIONS.each do |action|
-      define_method(action) do |*args, **kwargs|
-        raise AbstractMethodError.new "Action not defined for provider"
-      end
-    end
-
-    attr_reader :credentials
-
-    def initialize(credentials: {})
-      @credentials = credentials
-    end
   end
 end

--- a/lib/storage/providers/example.rb
+++ b/lib/storage/providers/example.rb
@@ -29,6 +29,11 @@ require_relative '../client'
 
 module Storage
   class ExampleClient < Client
-
+    def self.creds_schema
+      {
+        required_key: String,
+        timestamp: Integer
+      }
+    end
   end
 end


### PR DESCRIPTION
This PR introduces the idea of providers and clients to Flight Storage. Included is:
- An abstract class to base cloud provider clients off of
- A factory class to instantiate clients
- An example provider client to give an idea of credential validation

## `Client` class
The `Client` class is an abstract class. It isn't mean to be instantiated directly, but provide common logic to the future provider-specific subclasses in `lib/storage/providers/`. It defines error handlers for methods which _should_ all exist in subclasses, to make debugging easier. It also handles credential validation. Each subclass of `Client` is expected to have a `#creds_schema` method, of the form:
```ruby
def creds_schema
  {
    cred_key: String,
    another_key: Integer
  }
end
```

Where each top level key is a required credential key, and each value is the class that the key should be. At the moment, nested credential schemas are not supported, but I don't see why we would ever need to support them when a nested hash can be boiled down to a one-dimensional hash.

## `ClientFactory` class
The `ClientFactory` class provides a way to fetch the appropriate `Client` subclass. It has one public class method, `ClientFactory::for`. accepting a provider name symbol and a credentials hash. It checks the `PROVIDERS` constant to see if the provider exists, and fetches the class name if so.

## Future additions
The natural follow-on from this PR is to start implementing real cloud providers. We also need to think about an appropriate way of fetching user defined cloud credentials, as storing them locally to the project seems like a bad idea (data duplication and security hazard).