### PR TITLE
Set and configure cloud provider

### DIFF
--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -83,5 +83,11 @@ EOF
       c.summary = 'Set cloud storage provider'
       c.action Commands, :configure
     end
+
+    command :set do |c|
+      cli_syntax(c)
+      c.summary = 'Set credentials for chosen cloud storage provider'
+      c.action Commands, :set
+    end
   end
 end

--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -77,5 +77,11 @@ Say hello.
 EOF
     end
     alias_command :h, :hello
+
+    command :configure do |c|
+      cli_syntax(c)
+      c.summary = 'Set cloud storage provider'
+      c.action Commands, :configure
+    end
   end
 end

--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -68,6 +68,12 @@ module Storage
       end
     end
 
+    command :configure do |c|
+      cli_syntax(c)
+      c.summary = 'Configure credentials for chosen cloud storage provider'
+      c.action Commands, :configure
+    end
+
     command :hello do |c|
       cli_syntax(c)
       c.summary = 'Say hello'
@@ -78,15 +84,9 @@ EOF
     end
     alias_command :h, :hello
 
-    command :configure do |c|
-      cli_syntax(c)
-      c.summary = 'Set cloud storage provider'
-      c.action Commands, :configure
-    end
-
     command :set do |c|
       cli_syntax(c)
-      c.summary = 'Set credentials for chosen cloud storage provider'
+      c.summary = 'Set cloud storage provider'
       c.action Commands, :set
     end
   end

--- a/lib/storage/client_factory.rb
+++ b/lib/storage/client_factory.rb
@@ -27,13 +27,13 @@ require_relative 'providers/example'
 
 module Storage
   class ClientFactory
-    PROVIDERS = { 
-      example: ExampleClient
+    PROVIDERS = {
+      example: { klass: ExampleClient, friendly_name: "Example" }
     }
 
     def self.for(provider, credentials: {})
       raise "Invalid provider type" unless valid_provider?(provider)
-      (PROVIDERS[provider]).new(credentials: credentials)
+      (PROVIDERS[provider][:klass]).new(credentials: credentials)
     end
 
     private

--- a/lib/storage/command.rb
+++ b/lib/storage/command.rb
@@ -51,7 +51,7 @@ module Storage
 
     def client
       provider = Config.provider
-      creds = Config.provider_credentials
+      creds = Config.credentials
       @client ||= ClientFactory.for(provider, credentials: creds)
     end
   end

--- a/lib/storage/config.rb
+++ b/lib/storage/config.rb
@@ -91,7 +91,11 @@ module Storage
       end
 
       def provider
-        data.fetch(:provider).downcase.to_sym
+        provider = data.fetch(:provider)
+        if provider.nil?
+          raise "No provider set; please run `storage configure`"
+        end
+        provider.downcase.to_sym
       end
 
       def credentials

--- a/lib/storage/config.rb
+++ b/lib/storage/config.rb
@@ -27,6 +27,7 @@
 require 'xdg'
 require 'tty-config'
 require 'fileutils'
+require 'yaml'
 
 module Storage
   module Config
@@ -90,11 +91,25 @@ module Storage
       end
 
       def provider_credentials
-        # TODO: come up with a safe way to fetch credentials
-        Hash.new
+        creds_file = File.join(credentials_path, "#{provider.to_s}.yml")
+        FileUtils.mkdir_p(credentials_path) unless File.directory?(credentials_path)
+        FileUtils.touch(creds_file) unless File.file?(creds_file)
+
+        YAML.load_file(creds_file)
+      end
+
+      def storage_path
+        @storage_path ||= Pathname.new('flight/storage')
+      end
+
+      def credentials_path
+        # Expands to $HOME/.config/flight/credentials
+        @credentials_path ||=
+          storage_path.join('credentials').expand_path(xdg_config.home)
       end
 
       private
+
       def xdg_config
         @xdg_config ||= XDG::Config.new
       end

--- a/lib/storage/config.rb
+++ b/lib/storage/config.rb
@@ -86,26 +86,33 @@ module Storage
         @root ||= File.expand_path(File.join(__dir__, '..', '..'))
       end
 
-      def provider
-        data.fetch(:provider).downcase.to_sym
-      end
-
-      def provider_credentials
-        creds_file = File.join(credentials_path, "#{provider.to_s}.yml")
-        FileUtils.mkdir_p(credentials_path) unless File.directory?(credentials_path)
-        FileUtils.touch(creds_file) unless File.file?(creds_file)
-
-        YAML.load_file(creds_file)
-      end
-
       def storage_path
         @storage_path ||= Pathname.new('flight/storage')
       end
 
-      def credentials_path
+      def provider
+        data.fetch(:provider).downcase.to_sym
+      end
+
+      def credentials
+        FileUtils.touch(credentials_file)
+
+        YAML.load_file(credentials_file)
+      end
+
+      def credentials_file
+        file = File.join(credentials_dir, "#{provider.to_s}.yml")
+        FileUtils.touch(file)
+
+        @credentials_file ||= file
+      end
+
+      def credentials_dir
         # Expands to $HOME/.config/flight/credentials
-        @credentials_path ||=
-          storage_path.join('credentials').expand_path(xdg_config.home)
+        dir = storage_path.join('credentials').expand_path(xdg_config.home)
+        FileUtils.mkdir_p(dir)
+
+        @credentials_dir ||= dir
       end
 
       private

--- a/lib/storage/providers/example.rb
+++ b/lib/storage/providers/example.rb
@@ -32,7 +32,7 @@ module Storage
     def self.creds_schema
       {
         required_key: String,
-        timestamp: Integer
+        timestamp: String
       }
     end
   end


### PR DESCRIPTION
This PR introduces two new commands to Flight Storage: `set` and `configure`.

---

### `set`

The `set` command is used to pick a cloud storage provider. It uses `tty-prompt` to let the user pick a provider from an interactive list. The list is fetched from `ClientFactory::PROVIDERS`, so that the user can only pick from providers that we allow them to. The chosen provider's name is then saved to `etc/config.yml`. The aforementioned `PROVIDERS` hash has been updated to include "friendly" names for providers that we can use in user-facing parts of the application.

### `configure`

The `configure` command is used to set the required credentials for the user's chosen cloud provider. It uses `tty-prompt` to let the user enter their credentials (all credentials are considered to be `required`). The credential options are taken from the `creds_schema` class method on the user's chosen provider class. The chosen credentials are saved to the user's Flight config directory (`$HOME/.config/flight/storage/credentials/example.yml`). A few new methods have been added to `lib/storage/config.rb` to aid the fetching of filepaths relating to the reading/saving of credentials files.