### PR TITLE
Expand upon common client logic

### DIFF
--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -91,7 +91,7 @@ EOF
     end
     
     command :list do |c|
-      cli_syntax(c)
+      cli_syntax(c, "[DIRECTORY]")
       c.summary = "Display current directory"
       c.action Commands, :list
       c.description = "Display a tree showing the structure of the current directory"
@@ -99,18 +99,27 @@ EOF
     alias_command :ls, :list
     
     command :push do |c|
-      cli_syntax(c, "FILE")
+      cli_syntax(c, "SRC [DEST]")
       c.summary = "Save a file to the cloud"
       c.action Commands, :push
-      c.description = "Uploads a given file from local storage to the cloud"
+      c.description = <<~EOF
+      Uploads a given file from local storage to the cloud.
+      If no destination path is given at DEST, the file is pushed
+      to the root directory of the cloud storage.
+
+      EOF
     end
     alias_command :upload, :push
     
     command :pull do |c|
-      cli_syntax(c, "FILE")
+      cli_syntax(c, "FILE [DEST]")
       c.summary = "Save a file to this machine"
       c.action Commands, :pull
-      c.description = "Downloads a given file from the cloud to local storage"
+      c.description = <<~EOF
+      Downloads a given file from the cloud to local storage.
+      If no destination path is given at DEST, the file is pulled
+      to the current working directory.
+      EOF
     end
     alias_command :download, :pull
     

--- a/lib/storage/commands/delete.rb
+++ b/lib/storage/commands/delete.rb
@@ -30,7 +30,12 @@ module Storage
   module Commands
     class Delete < Command
       def run
-        client.delete
+        # ARGS:
+        # [ target_file ]
+        
+        if client.delete(args[0])
+          puts "File at #{args} deleted"
+        end
       end
     end
   end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS
         # [ directory ]
 
-        client.list(args[0] || '')
+        client.list(*args[0])
       end
     end
   end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -30,7 +30,10 @@ module Storage
   module Commands
     class List < Command
       def run
-        client.list
+        # ARGS
+        # [ directory ]
+
+        client.list(args[0])
       end
     end
   end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS
         # [ directory ]
 
-        client.list(args[0])
+        client.list(args[0] || '')
       end
     end
   end

--- a/lib/storage/commands/pull.rb
+++ b/lib/storage/commands/pull.rb
@@ -30,7 +30,12 @@ module Storage
   module Commands
     class Pull < Command
       def run
-        client.pull
+        # ARGS
+        # [ source_file, destination ]
+
+        if client.pull(args[0], args[1])
+          "File '#{args[0]}' downloaded to '#{File.expand_path(args[1])}'"
+        end
       end
     end
   end

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -33,10 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        if client.pull(args[0], args[1])
+        if client.push(args[0], args[1])
           "File '#{File.expand(args[0])}' uploaded to '#{args[1]}'"
         end
-        client.push
       end
     end
   end

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -30,6 +30,12 @@ module Storage
   module Commands
     class Push < Command
       def run
+        # ARGS
+        # [ source_file, destination ]
+
+        if client.pull(args[0], args[1])
+          "File '#{File.expand(args[0])}' uploaded to '#{args[1]}'"
+        end
         client.push
       end
     end

--- a/lib/storage/errors.rb
+++ b/lib/storage/errors.rb
@@ -27,4 +27,18 @@
 module Storage
   StorageError = Class.new(RuntimeError)
   AbstractMethodError = Class.new(StandardError)
+
+  class ResourceNotFoundError < StandardError
+    def initialize(path)
+      msg = "Remote resource '#{path}' not found"
+      super(msg)
+    end
+  end
+
+  class ResourceExistsError < StandardError
+    def initialize(path)
+      msg = "Remote resource already exists at '#{path}'"
+      super(msg)
+    end
+  end
 end


### PR DESCRIPTION
This PR slightly expands on what each of the commands should be doing before/after yielding to a `Client` subclass. Some extra arguments have been added to the commands, and the command files have been updated to take advantage of them.

Each of the actions written like `if client._action_` are expected to return a truth-y value. It ought to be left to the subclasses to raise any errors that are encountered.

Some new custom error classes have been introduced. It is inevitable that any errors returned by the varying cloud storage providers will be entirely unique from one another. In the event that an _expected_ error is caught in a provider subclass, we should use one of the new uniform error classes to relay the problem to the user.