### PR TITLE
Fix command typos and validate input

### DIFF
--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -95,6 +95,7 @@ EOF
       c.summary = "Display current directory"
       c.action Commands, :list
       c.description = "Display a tree showing the structure of the current directory"
+      c.option "--tree", "Show results in a user-friendly tree structure"
     end
     alias_command :ls, :list
     

--- a/lib/storage/commands/delete.rb
+++ b/lib/storage/commands/delete.rb
@@ -33,9 +33,9 @@ module Storage
         # ARGS:
         # [ target_file ]
         
-        args[0] = args[0].gsub(%r{/+}, "/")
-        if client.delete(args[0])
-          puts "File at #{args[0]} deleted"
+        validated = args[0].gsub(%r{/+}, "/")
+        if client.delete(validated)
+          puts "File at #{validated} deleted"
         end
       end
     end

--- a/lib/storage/commands/delete.rb
+++ b/lib/storage/commands/delete.rb
@@ -33,8 +33,9 @@ module Storage
         # ARGS:
         # [ target_file ]
         
+        args[0] = args[0].gsub(%r{/+}, "/")
         if client.delete(args[0])
-          puts "File at #{args} deleted"
+          puts "File at #{args[0]} deleted"
         end
       end
     end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -32,9 +32,11 @@ module Storage
       def run
         # ARGS
         # [ directory ]
+        # OPTS
+        # [ tree ]
 
         args[0] = args[0].gsub(%r{/+}, "/")
-        client.list(*args[0])
+        client.list(@options.tree, *args[0])
       end
     end
   end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -35,8 +35,8 @@ module Storage
         # OPTS
         # [ tree ]
 
-        args[0] = args[0].gsub(%r{/+}, "/")
-        client.list(@options.tree, *args[0])
+        validated = args[0].gsub(%r{/+}, "/")
+        client.list(@options.tree, *validated)
       end
     end
   end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -33,6 +33,7 @@ module Storage
         # ARGS
         # [ directory ]
 
+        args[0] = args[0].gsub(%r{/+}, "/")
         client.list(*args[0])
       end
     end

--- a/lib/storage/commands/pull.rb
+++ b/lib/storage/commands/pull.rb
@@ -33,8 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
+        args = args.map{ |a| a.gsub(%r{/+}, "/") }
         if client.pull(args[0], args[1])
-          "File '#{args[0]}' downloaded to '#{File.expand_path(args[1])}'"
+          puts "File '#{args[0]}' downloaded to '#{File.expand_path(args[1])}'"
         end
       end
     end

--- a/lib/storage/commands/pull.rb
+++ b/lib/storage/commands/pull.rb
@@ -33,9 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        args = args.map{ |a| a.gsub(%r{/+}, "/") }
-        if client.pull(args[0], args[1])
-          puts "File '#{args[0]}' downloaded to '#{File.expand_path(args[1])}'"
+        valid_args = args.map{ |a| a.gsub(%r{/+}, "/") }
+        if client.pull(valid_args[0], valid_args[1])
+          puts "File '#{valid_args[0]}' downloaded to '#{File.expand_path(valid_args[1])}'"
         end
       end
     end

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -33,8 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
+        args = args.map{ |a| a.gsub(%r{/+}, "/") }
         if client.push(args[0], args[1])
-          "File '#{File.expand(args[0])}' uploaded to '#{args[1]}'"
+          puts "File '#{File.expand_path(args[0])}' uploaded to '#{args[1]}'"
         end
       end
     end

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -33,9 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        args = args.map{ |a| a.gsub(%r{/+}, "/") }
-        if client.push(args[0], args[1])
-          puts "File '#{File.expand_path(args[0])}' uploaded to '#{args[1]}'"
+        valid_args = args.map{ |a| a.gsub(%r{/+}, "/") }
+        if client.push(valid_args[0], valid_args[1])
+          puts "File '#{File.expand_path(valid_args[0])}' uploaded to '#{valid_args[1]}'"
         end
       end
     end


### PR DESCRIPTION
Fixed a couple of typos I missed when reviewing previously, and substituted any sequence of `/`s longer than one with a single `/` in file paths. Also added an option to `list` to specify whether to output results as a tree