### PR TITLE
Standardise commands

### DIFF
--- a/lib/storage/commands/delete.rb
+++ b/lib/storage/commands/delete.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS:
         # [ target_file ]
         
-        validated = args[0].gsub(%r{/+}, "/")
+        validated = args[0].prepend("/").gsub(%r{/+}, "/")
         if client.delete(validated)
           puts "File at #{validated} deleted"
         end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -35,7 +35,7 @@ module Storage
         # OPTS
         # [ tree ]
 
-        validated = args[0]&.gsub(%r{/+}, "/")
+        validated = args[0]&.prepend("/")&.gsub(%r{/+}, "/")
         puts client.list(*validated, tree: @options.tree)
       end
     end

--- a/lib/storage/commands/pull.rb
+++ b/lib/storage/commands/pull.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        valid_args = args.map { |a| a&.gsub(%r{/+}, "/") }
+        valid_args = args.map { |a| a&.prepend("/")&.gsub(%r{/+}, "/") }
 
         source = valid_args[0]
         dest_file = File.basename(source)

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        valid_args = args.map { |a| a&.gsub(%r{/+}, "/") }
+        valid_args = args.map { |a| a&.prepend("/")&.gsub(%r{/+}, "/") }
 
         source = File.expand_path(valid_args[0])
         dest_file = File.basename(source)


### PR DESCRIPTION
Currently the file path arguments in each command may or may not start with `/`, regardless of the fact that they're all considered to implicitly start from the root directory anyway. Considering that an empty path takes the value of `/` by default, it seems logical that all paths should start with `/` regardless of how they are specified.

E.g. running `list documents/foo/bar` will pass `/documents/foo/bar` to the relevant `list` command.

This prevents each command needing to check which prefix they've been given before changing it to the relevant provider's desired format.