### PR TITLE
Fix command bugs

### DIFF
--- a/lib/storage/commands/delete.rb
+++ b/lib/storage/commands/delete.rb
@@ -33,7 +33,7 @@ module Storage
         # ARGS:
         # [ target_file ]
         
-        validated = args[0].prepend("/").gsub(%r{/+}, "/")
+        validated = "/#{args[0]}".gsub(%r{/+}, "/")
         if client.delete(validated)
           puts "File at #{validated} deleted"
         end

--- a/lib/storage/commands/list.rb
+++ b/lib/storage/commands/list.rb
@@ -35,7 +35,7 @@ module Storage
         # OPTS
         # [ tree ]
 
-        validated = args[0]&.prepend("/")&.gsub(%r{/+}, "/")
+        validated = "/#{args[0]}"&.gsub(%r{/+}, "/")
         puts client.list(*validated, tree: @options.tree)
       end
     end

--- a/lib/storage/commands/pull.rb
+++ b/lib/storage/commands/pull.rb
@@ -33,7 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        valid_args = args.map { |a| a&.prepend("/")&.gsub(%r{/+}, "/") }
+        valid_args = args.dup
+        valid_args[0] = valid_args[0].dup.prepend("/")
+        valid_args = valid_args.map { |a| a&.gsub(%r{/+}, "/") }
 
         source = valid_args[0]
         dest_file = File.basename(source)

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -33,7 +33,9 @@ module Storage
         # ARGS
         # [ source_file, destination ]
 
-        valid_args = args.map { |a| a&.prepend("/")&.gsub(%r{/+}, "/") }
+        valid_args = args.dup
+        valid_args[1] = valid_args[1].dup.prepend("/")
+        valid_args = valid_args.map { |a| a&.gsub(%r{/+}, "/") }
 
         source = File.expand_path(valid_args[0])
         dest_file = File.basename(source)

--- a/lib/storage/commands/push.rb
+++ b/lib/storage/commands/push.rb
@@ -34,7 +34,7 @@ module Storage
         # [ source_file, destination ]
 
         valid_args = args.dup
-        valid_args[1] = valid_args[1].dup.prepend("/")
+        valid_args[1] = valid_args[1].dup&.prepend("/")
         valid_args = valid_args.map { |a| a&.gsub(%r{/+}, "/") }
 
         source = File.expand_path(valid_args[0])

--- a/lib/storage/providers/azure.rb
+++ b/lib/storage/providers/azure.rb
@@ -254,7 +254,6 @@ module Storage
         `cat #{chunk_files.map(&:path).join(' ')} > #{dest}`
       end
       chunk_files.map(&:unlink)
-      p File.size(dest)
     end
 
     def query_tree(directory='')


### PR DESCRIPTION
Fix the oversights in the command standardisation. Now only filepaths used by the cloud will be prepended with `/`.