### PR TITLE
Dropbox provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,6 @@ gem 'azure-storage-file'
 
 # AWS provider gems
 gem 'aws-sdk-s3'
+
+# Dropbox provider gems
+gem 'dropbox_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
       paint (~> 2.1.0)
       slop (~> 4.8)
     connection_pool (2.3.0)
+    dropbox_api (0.1.21)
+      faraday (< 3.0)
+      oauth2 (~> 1.1)
     faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -64,17 +67,27 @@ GEM
       faraday (~> 1.0)
     highline (2.0.3)
     jmespath (1.6.1)
+    jwt (2.5.0)
     mini_portile2 (2.8.0)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
     multipart-post (2.2.3)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    oauth2 (1.4.11)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
     paint (2.1.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
     racc (1.6.0)
+    rack (3.0.0)
     ruby2_keywords (0.0.5)
     slop (4.9.3)
     strings (0.2.1)
@@ -109,6 +122,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage-file
   commander-openflighthpc (~> 2.2.0)
+  dropbox_api
   tty-config
   tty-prompt
   tty-table

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Flight Storage currently supports the following cloud storage providers:
 
 - Amazon S3 ([setup](docs/aws_s3.md))
 - Azure File Service ([setup](docs/azure.md))
+- Dropbox ([setup](docs/dropbox.md))
 
 Please follow the setup guide for your chosen provider.
 

--- a/docs/dropbox.md
+++ b/docs/dropbox.md
@@ -1,0 +1,43 @@
+# Setting up Flight Storage with your Dropbox account
+
+This doc goes over the steps required to set up a Dropbox account to be used with Flight Storage.
+
+## Create an app
+
+From the Dropbox app page ([link](https://www.dropbox.com/developers/apps/)), click `Create app`.
+
+The following settings are the recommended settings; if you know what you are doing, most of them can be changed to suit your preferences.
+
+### Create a new app on the DBX Platform
+
+1. Choose an API - Scoped access
+
+1. Choose the type of access you need - Full Dropbox
+
+1. Name your app - Can be any name, "Flight Storage" is recommended.
+
+### Settings
+
+The only relevant information here is **Generate access token** under the `OAuth 2` section. Click the `Generate` button and note the generated code as this is a required credential for Flight Storage. This code will expire 4 hours after generation; you will need to return to this page to generate a new code when it does.
+
+### Permissions
+
+This tab has a large number of checkbox options to give Flight Storage access to various aspects of your Dropbox account. The only options which must be selected are:
+
+* `account_info.read` (Selected by default)
+
+* `files.metadata.read`
+
+* `files.content.write`
+
+* `files.content.read`
+
+---
+
+Click `Submit`
+
+## Configure the Dropbox provider in Flight Storage
+
+Once you have completed the creation steps, you are ready to configure Flight Storage to use your Dropbox account. Run `bin/storage configure` (source) / `flight storage configure` (package), and enter the code that you saved earlier.
+
+Once you have entered the code, run `bin/storage list` (source) / `flight storage list` (package) to ensure that your code is correct. If you get an output matching that of your account contents, you have successfully set up Flight Storage with your Dropbox account.

--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -116,5 +116,13 @@ module Storage
       c.description = "Delete a given file from the cloud"
     end
     alias_command :rm, :delete
+    
+    command :mkdir do |c|
+      cli_syntax(c, "DIRECTORY")
+      c.summary = "Create a directory in the cloud"
+      c.action Commands, :mkdir
+      c.description = "Creates a directory in the cloud"
+      c.option "-p", "--parents", "Create parent directories if they don't already exist"
+    end
   end
 end

--- a/lib/storage/cli.rb
+++ b/lib/storage/cli.rb
@@ -124,5 +124,13 @@ module Storage
       c.description = "Creates a directory in the cloud"
       c.option "-p", "--parents", "Create parent directories if they don't already exist"
     end
+    
+    command :rmdir do |c|
+      cli_syntax(c, "DIRECTORY")
+      c.summary = "Delete a directory from the cloud"
+      c.action Commands, :rmdir
+      c.description = "Deletes a directory from the cloud"
+      c.option "-r", "--recursive", "Also delete contents of directory"
+    end
   end
 end

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -27,7 +27,7 @@
 
 module Storage
   class Client
-    ACTIONS = %w(list push pull delete mkdir)
+    ACTIONS = %w(list push pull delete mkdir rmdir)
 
     ACTIONS.each do |action|
       define_method(action) do |*args, **kwargs|

--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -27,7 +27,7 @@
 
 module Storage
   class Client
-    ACTIONS = %w(list push pull delete)
+    ACTIONS = %w(list push pull delete mkdir)
 
     ACTIONS.each do |action|
       define_method(action) do |*args, **kwargs|

--- a/lib/storage/clients/aws.rb
+++ b/lib/storage/clients/aws.rb
@@ -104,6 +104,30 @@ module Storage
       end
     end
     
+    def mkdir(path, make_parents)
+      path = path.delete_prefix("/")
+      if make_parents
+        dirs = path.delete_prefix("/").split("/")
+        puts dirs.inspect
+        index = 0
+        while index < dirs.size
+          client.put_object(
+            bucket: @credentials[:bucket_name],
+            key: (dirs[0..index].join("/") + "/")
+          )
+          puts (dirs[0..index].join("/") + "/")
+          index += 1
+        end
+      
+      else
+        dir_tree.dig(*path.split("/")[0..-2])
+        client.put_object(
+          bucket: @credentials[:bucket_name],
+          key: path
+        )
+      end
+    end
+    
     # Convert the bucket contents into a tree-like hash
     def to_hash(prefix)
       children = []

--- a/lib/storage/clients/aws.rb
+++ b/lib/storage/clients/aws.rb
@@ -132,17 +132,12 @@ module Storage
       path = path.delete_prefix("/")
       if resource.bucket(@credentials[:bucket_name]).object(path).exists?
         objs = resource.bucket(@credentials[:bucket_name]).objects({prefix: path})
-        if recursive
+        dirs = path.split("/")
+        if recursive || dir_tree.dig(*dirs).to_hash[dirs.last].empty?
           objs.batch_delete!
           true
         else
-          dirs = path.split("/")
-          if dir_tree.dig(*dirs).to_hash[dirs.last].empty?
-            objs.batch_delete!
-            true
-          else
-            raise DirectoryNotEmptyError, path
-          end
+          raise DirectoryNotEmptyError, path
         end
       else
         raise ResourceNotFoundError, path

--- a/lib/storage/clients/aws.rb
+++ b/lib/storage/clients/aws.rb
@@ -106,19 +106,19 @@ module Storage
     
     def mkdir(path, make_parents)
       path = path.delete_prefix("/")
-      if make_parents
-        dirs = path.delete_prefix("/").split("/")
-        puts dirs.inspect
+      if resource.bucket(@credentials[:bucket_name]).object(path).exists?
+        raise ResourceExistsError, path
+      elsif make_parents
+        dirs = path.split("/")
         index = 0
         while index < dirs.size
           client.put_object(
             bucket: @credentials[:bucket_name],
             key: (dirs[0..index].join("/") + "/")
           )
-          puts (dirs[0..index].join("/") + "/")
           index += 1
         end
-      
+        true
       else
         dir_tree.dig(*path.split("/")[0..-2])
         client.put_object(

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -116,6 +116,17 @@ module Storage
       end
     end
     
+    def rmdir(path, recursive)
+      dirs = path[1..-1].split("/")
+      subtree = dir_tree.dig(*dirs)
+      
+      if recursive || subtree.to_hash[dirs.last].empty?
+        client.delete(path[0..-2])
+      else
+        raise DirectoryNotEmptyError, path
+      end
+    end
+    
     def to_hash(prefix)
 
       children = client.list_folder(prefix).entries

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -60,7 +60,7 @@ module Storage
     end
     
     def dir_tree
-      @dir_tree = Tree.new("/", to_hash(""))
+      @dir_tree ||= Tree.new("/", to_hash(""))
     end
     
     def pull(source, dest)

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -47,16 +47,16 @@ module Storage
     def list(path="/", tree: false)
       path = path.delete_prefix("/")
       subtree = dir_tree.dig(*path.split("/"))
-      msg = ""
-      if tree
-        msg << subtree.show
-      else
-        subtree.subdirs.each do |child|
-          msg << child.name + "/\n"
+      "".tap do |msg|
+        if tree
+          msg << subtree.show
+        else
+          subtree.subdirs.each do |child|
+            msg << child.name + "/\n"
+          end
+          msg << subtree.files.join("\n")
         end
-        msg << subtree.files.join("\n")
       end
-      msg
     end
     
     def dir_tree

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -1,0 +1,133 @@
+#==============================================================================
+# Copyright (C) 2022-present Alces Flight Ltd.
+#
+# This file is part of Flight Storage.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Storage is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Storage. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Storage, please visit:
+# https://github.com/openflighthpc/flight-storage
+#==============================================================================
+require 'dropbox_api'
+
+require_relative '../client'
+require_relative '../tree'
+
+module Storage
+  class DropboxClient < Client
+    FRIENDLY_NAME = "Dropbox"
+    
+    TYPES = {
+      file: DropboxApi::Metadata::File,
+      directory: DropboxApi::Metadata::Folder
+    }
+  
+    def self.creds_schema
+      {
+        access_token: String
+      }
+    end
+    
+    def list(path="/", tree: false)
+      path = path.delete_prefix("/")
+      subtree = dir_tree.dig(*path.split("/"))
+      msg = ""
+      if tree
+        msg << subtree.show
+      else
+        subtree.subdirs.each do |child|
+          msg << child.name + "/\n"
+        end
+        msg << subtree.files.join("\n")
+      end
+      msg
+    end
+    
+    def dir_tree
+      @dir_tree = Tree.new("/", to_hash(""))
+    end
+    
+    def pull(source, dest)
+      if dir_tree.file_exists?(source)
+        content = ""
+        file = client.download(source) do |chunk|
+          content << chunk
+        end
+        
+        File.open(File.expand_path(dest), "w") do |f|
+          f.write(content)
+        end
+        
+      else
+        raise ResourceNotFoundError, source
+      end
+      dest
+    end
+    
+    def push(source, dest)
+      if dir_tree.file_exists?(dest)
+        raise ResourceExistsError, dest
+      end
+      
+      File.open(source) do |file|
+        client.upload_by_chunks(dest, file, {mute: true})
+      end
+    end
+    
+    def delete(path)
+      if dir_tree.file_exists?(path)
+        client.delete(path)
+      else
+        raise ResourceNotFoundError, path
+      end
+    end
+    
+    def to_hash(prefix)
+
+      children = client.list_folder(prefix).entries
+
+      [].tap do |a|
+        children.each do |child|
+          if child.is_a?(TYPES[:file])
+            a << child.name
+          elsif child.is_a?(TYPES[:directory])
+            a << {child.name => to_hash("/" + child.name)}
+          end
+        end
+      end
+    end
+    
+    def client
+      @client ||= DropboxApi::Client.new(@credentials[:access_token])
+      # Attempt to access account
+      begin
+        @client.list_folder("", {limit: 1})
+      rescue DropboxApi::Errors::ExpiredAccessTokenError
+        raise ExpiredCredentialsError, FRIENDLY_NAME
+      rescue DropboxApi::Errors::HttpError
+        raise InvalidCredentialsError, FRIENDLY_NAME
+      end
+      @client
+    end
+    
+    def filesize(src)
+      pretty_filesize(client.get_metadata(src).size)
+    end
+  end
+end

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -108,7 +108,7 @@ module Storage
     def mkdir(path, make_parents)
       begin
         if !make_parents
-          dir_tree.dig(*path.split("/")[0..-2])
+          dir_tree.dig(*path[1..-1].split("/")[0..-2])
         end
         client.create_folder(path[0..-2])
       rescue DropboxApi::Errors::FolderConflictError

--- a/lib/storage/clients/dropbox.rb
+++ b/lib/storage/clients/dropbox.rb
@@ -105,6 +105,17 @@ module Storage
       end
     end
     
+    def mkdir(path, make_parents)
+      begin
+        if !make_parents
+          dir_tree.dig(*path.split("/")[0..-2])
+        end
+        client.create_folder(path[0..-2])
+      rescue DropboxApi::Errors::FolderConflictError
+        raise ResourceExistsError, path
+      end
+    end
+    
     def to_hash(prefix)
 
       children = client.list_folder(prefix).entries

--- a/lib/storage/commands/mkdir.rb
+++ b/lib/storage/commands/mkdir.rb
@@ -35,7 +35,7 @@ module Storage
         # OPTS
         # [ parents ]
         
-        validated = "/#{args[0]}"&.gsub(%r{/+}, "/")
+        validated = "/#{args[0]}/"&.gsub(%r{/+}, "/")
 
         if client.mkdir(validated, @options.parents)
           puts "Directory '#{validated}' created."

--- a/lib/storage/commands/mkdir.rb
+++ b/lib/storage/commands/mkdir.rb
@@ -24,38 +24,22 @@
 # For more information on Flight Storage, please visit:
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
-require_relative 'commands/avail'
-require_relative 'commands/configure'
-require_relative 'commands/delete'
-require_relative 'commands/list'
-require_relative 'commands/pull'
-require_relative 'commands/push'
-require_relative 'commands/set'
-require_relative 'commands/mkdir'
+require_relative '../command'
 
 module Storage
   module Commands
-    class << self
-      def method_missing(s, *a, &b)
-        if clazz = to_class(s)
-          clazz.new(*a).run!
-        else
-          raise 'command not defined'
-        end
-      end
+    class Mkdir < Command
+      def run
+        # ARGS
+        # [ directory ]
+        # OPTS
+        # [ parents ]
+        
+        validated = "/#{args[0]}"&.gsub(%r{/+}, "/")
 
-      def respond_to_missing?(s)
-        !!to_class(s)
-      end
-
-      private
-      def to_class(s)
-        s.to_s.split('-').reduce(self) do |clazz, p|
-          p.gsub!(/_(.)/) {|a| a[1].upcase}
-          clazz.const_get(p[0].upcase + p[1..-1])
+        if client.mkdir(validated, @options.parents)
+          puts "Directory '#{validated}' created."
         end
-      rescue NameError
-        nil
       end
     end
   end

--- a/lib/storage/commands/rmdir.rb
+++ b/lib/storage/commands/rmdir.rb
@@ -24,39 +24,22 @@
 # For more information on Flight Storage, please visit:
 # https://github.com/openflighthpc/flight-storage
 #==============================================================================
-require_relative 'commands/avail'
-require_relative 'commands/configure'
-require_relative 'commands/delete'
-require_relative 'commands/list'
-require_relative 'commands/pull'
-require_relative 'commands/push'
-require_relative 'commands/set'
-require_relative 'commands/mkdir'
-require_relative 'commands/rmdir'
+require_relative '../command'
 
 module Storage
   module Commands
-    class << self
-      def method_missing(s, *a, &b)
-        if clazz = to_class(s)
-          clazz.new(*a).run!
-        else
-          raise 'command not defined'
-        end
-      end
+    class Rmdir < Command
+      def run
+        # ARGS
+        # [ directory ]
+        # OPTS
+        # [ recursive ]
+        
+        validated = "/#{args[0]}/"&.gsub(%r{/+}, "/")
 
-      def respond_to_missing?(s)
-        !!to_class(s)
-      end
-
-      private
-      def to_class(s)
-        s.to_s.split('-').reduce(self) do |clazz, p|
-          p.gsub!(/_(.)/) {|a| a[1].upcase}
-          clazz.const_get(p[0].upcase + p[1..-1])
+        if client.rmdir(validated, @options.recursive)
+          puts "Directory '#{validated}' deleted."
         end
-      rescue NameError
-        nil
       end
     end
   end

--- a/lib/storage/errors.rb
+++ b/lib/storage/errors.rb
@@ -30,14 +30,14 @@ module Storage
 
   class InvalidCredentialsError < StandardError
     def initialize(provider)
-      msg = "Invalid credentials given for provider '#{provider}'"
+      msg = "Invalid credentials given for provider '#{provider}'. Try 'storage configure' to set new credentials."
       super(msg)
     end
   end
   
   class ExpiredCredentialsError < StandardError
     def initialize(provider)
-      msg = "Credentials for '#{provider}' have expired."
+      msg = "Credentials for '#{provider}' have expired. Try 'storage configure' to set new credentials."
       super(msg)
     end
   end

--- a/lib/storage/errors.rb
+++ b/lib/storage/errors.rb
@@ -62,4 +62,11 @@ module Storage
       super(msg)
     end
   end
+  
+  class DirectoryNotEmptyError < StandardError
+    def initialize(path)
+      msg = "Directory '#{path}' is non-empty, use the '-r' option to delete it and all contents"
+      super(msg)
+    end
+  end
 end

--- a/lib/storage/errors.rb
+++ b/lib/storage/errors.rb
@@ -34,6 +34,13 @@ module Storage
       super(msg)
     end
   end
+  
+  class ExpiredCredentialsError < StandardError
+    def initialize(provider)
+      msg = "Credentials for '#{provider}' have expired."
+      super(msg)
+    end
+  end
 
   class ResourceNotFoundError < StandardError
     def initialize(path)

--- a/lib/storage/errors.rb
+++ b/lib/storage/errors.rb
@@ -76,4 +76,11 @@ module Storage
       super(msg)
     end
   end
+  
+  class InsufficientSpaceError < StandardError
+    def initialize(path, pretty_size, pretty_remaining)
+      msg = "The file '#{path}' (#{pretty_size}) exceeds the #{pretty_remaining} of space remaining for this provider."
+      super(msg)
+    end
+  end
 end

--- a/lib/storage/tree.rb
+++ b/lib/storage/tree.rb
@@ -77,7 +77,7 @@ module Storage
 
       if !subdir
         # No such subdirectory
-        raise "The directory '#{File.join(*path)}' could not be found"
+        raise ResourceNotFoundError, File.join(*path).to_s
       elsif iter + 1 == path.length
         # Base case
         return subdir


### PR DESCRIPTION
This PR introduces Dropbox as a provider, with the associated implementations of `push`, `pull`, `list` and `delete`. It requires just one credential - an access token - however this token expires 4 hours after generation and must be refreshed and reset manually by the user when it does so.

---

This PR also introduces a new type of error to give feedback specifically about credentials which have expired, as opposed to those which are simply invalid. It also slightly amends both types of credential error so as to remind the user to run `storage configure` to set valid credentials.