### PR TITLE
Handle nil credentials

### DIFF
--- a/lib/storage/client.rb
+++ b/lib/storage/client.rb
@@ -59,15 +59,12 @@ module Storage
 
     private
 
-    def validate_credentials(hash)
-      hash.has_shape?(self.class.creds_schema)
-    end
-  end
-end
+    def validate_credentials(creds)
+      return false if !creds
 
-class Hash
-  def has_shape?(shape)
-    # Currently only supports single level hashes
-    (shape.keys - self.keys).empty? && all? { |k, v| shape[k] === v }
+      shape = self.class.creds_schema
+
+      (shape.keys - creds.keys).empty? && all? { |k, v| shape[k] === v }
+    end
   end
 end


### PR DESCRIPTION
This PR adds an extra step to fetching credentials to handle an empty credentials file (which would exist if the user has run `set` and never run `configure` for that provider). It also moves the `has_shape?` logic that I added to the `Hash` class to the `validate_credentials` method.